### PR TITLE
Config file usage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+* Update config.go to use a location in /etc as the default config location once we decide how to package and install chmgt

--- a/chmgt.go
+++ b/chmgt.go
@@ -1,20 +1,25 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"time"
 
-	"github.com/mattjw79/chmgt/routing"
+	"chmgt/routing"
 )
 
 func main() {
-	// Let the user know that we're starting
+	// Pull in config
+	config := ReadConfig()
+	log.Printf("config:\n%+v\n", config)
+
+	// Let the user know tt we're starting
 	log.Println("Starting server")
 	router := routing.NewRouter()
 	srv := &http.Server{
 		Handler:      router,
-		Addr:         ":8080",
+		Addr:         fmt.Sprintf("%s:%s", config.Interface, config.Port),
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}

--- a/config
+++ b/config
@@ -1,0 +1,2 @@
+interface = "localhost"
+port = "8080"

--- a/config.go
+++ b/config.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config is a struct of expected configuration elements
+type Config struct {
+	Interface string
+	Port      string
+}
+
+// ReadConfig can accept a runtime flag of --config with a filename or default to ./config.
+// This should probably be changed to somewhere in /etc once we package up chmgt for use.
+func ReadConfig() Config {
+	var configfile string
+	flag.StringVar(&configfile, "config", "./config", "Config file to be used")
+	flag.Parse()
+	log.Printf("Attempting to use config file: %s", configfile)
+
+	_, err := os.Stat(configfile)
+	if err != nil {
+		log.Fatal("Config file is missing: ", configfile)
+	}
+
+	var config Config
+	if _, err := toml.DecodeFile(configfile, &config); err != nil {
+		log.Fatal(err)
+	}
+
+	return config
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -3,9 +3,10 @@ package routing
 import (
 	"net/http"
 
+	"chmgt/handling"
+
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
-	"github.com/mattjw79/chmgt/handling"
 )
 
 // Route provides all of the items needed to build a route


### PR DESCRIPTION
Basic config file created and used to define interface and port chmgt will run on. Added a TODO.md as well. At this point it is similar usage as the README.md, but added for a concise list of things to do. Add as necessary.

Removed reference to "github.com/mattjw79/" in import statements as well.