### PR TITLE
Cleaned up config reading

### DIFF
--- a/chmgt.go
+++ b/chmgt.go
@@ -43,11 +43,14 @@ func main() {
 	var (
 		configFileFlag string //config file to use
 	)
-	flag.StringVar(&configFileFlag, "config", "./config", "Config file path to be used.")
+	flag.StringVar(&configFileFlag, "config", "", "Config file path to be used.")
 	flag.Parse()
 
 	// Pull in config
-	config := ReadConfig(configFileFlag)
+	config, err := ReadConfig(configFileFlag)
+	if err != nil {
+		log.Fatal(err)
+	}
 	log.Printf("config:\n%+v\n", config)
 
 	// Create the database if it doesn't exist
@@ -59,7 +62,7 @@ func main() {
 		}
 	}
 
-	// Let the user know tt we're starting
+	// Let the user know that we're starting
 	log.Println("Starting server")
 	router := routing.NewRouter()
 	srv := &http.Server{


### PR DESCRIPTION
-   Changed the default for the config flag to an empty string
-   Modified variable names in ReadConfig to more closely conform to convention
-   Added error checking for user data
-   Moved error handling out of the ReadConfig function and into main
-   Return on successful config read
-   Only use default paths if config flag was not given