### PR TITLE
Log destination

### DIFF
--- a/chmgt.go
+++ b/chmgt.go
@@ -19,6 +19,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if config.Server.LogFile != "" {
+		logFile, err := os.OpenFile(config.Server.LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			log.Fatalf("unable to open log file: %v", err)
+		}
+		defer logFile.Close()
+		log.SetOutput(logFile)
+	}
 	handler, err := handling.NewHandler(config)
 	if err != nil {
 		log.Fatal(err)

--- a/config.toml
+++ b/config.toml
@@ -35,7 +35,7 @@
 #name = "chmgt"
 
 # authDB: Database to authenticate against
-#authDB = "admin"
+#authDB = ""
 
 # username: Database administration username
 #username = "chmgt"

--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,10 @@
 #             incoming requests. The default is port 8080.
 #listenPort = 8080
 
+# logFile: Location in which to store log messages. The default log
+#          location is STDOUT and not a file.
+#logFile = ""
+
 # useProxyHeaders: Use the value found in the X-Forwarded-For, X-Real-IP,
 #                  X-Forwarded-Proto and RFC7239 Forwarded headers. This
 #                  should only be used when the server is running behind
@@ -31,7 +35,7 @@
 #name = "chmgt"
 
 # authDB: Database to authenticate against
-#authDB = ""
+authDB = "admin"
 
 # username: Database administration username
 #username = "chmgt"

--- a/config.toml
+++ b/config.toml
@@ -35,7 +35,7 @@
 #name = "chmgt"
 
 # authDB: Database to authenticate against
-authDB = "admin"
+#authDB = "admin"
 
 # username: Database administration username
 #username = "chmgt"

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 type serverConfig struct {
 	ListenIP        string `toml:"listenIP"`
 	ListenPort      int    `toml:"listenPort"`
+	LogFile         string `toml:"logFile"`
 	UseProxyHeaders bool   `toml:"useProxyHeaders"`
 	SessionSecret   string `toml:"sessionSecret"`
 	SessionTimeout  int    `toml:"sessionTimeout"`


### PR DESCRIPTION
Allow logging to a file rather than STDOUT only. The default is still STDOUT when an empty string is defined in the config.